### PR TITLE
Feat/login

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -27,26 +27,33 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
-
-	// ✅ 여기 수정!
+// ✅ OAuth 관련
 	implementation 'com.google.oauth-client:google-oauth-client:1.34.1'
-
 	implementation 'com.google.api-client:google-api-client:2.2.0'
 	implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
 
+// ✅ JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
+// ✅ Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+// ✅ Jackson (Swagger와 호환 맞추기)
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
+
 }
 
 

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -25,8 +25,17 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll() // 로그인 관련은 모두 허용
-                        .anyRequest().authenticated() // 나머지는 인증 필요
+                        .requestMatchers(
+                                "/api/auth/**",                    // 로그인 관련은 허용
+                                "/v3/api-docs/**",                 // Swagger 문서
+                                "/swagger-ui/**",                 // Swagger UI
+                                "/swagger-ui.html",               // Swagger HTML 진입점
+                                "/openapi/**",              // 우리가 설정한 API docs 커스텀 경로
+                                "/docs/**",                 // 우리가 커스터마이징한 Swagger UI 경로
+                                "/swagger-resources/**",          // Swagger 리소스
+                                "/webjars/**"                     // Swagger 스타일/스크립트
+                        ).permitAll()
+                        .anyRequest().authenticated()           // 나머지는 인증 필요
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/demo/src/main/java/com/example/demo/controller/AuthController.java
+++ b/demo/src/main/java/com/example/demo/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.demo.controller;
 import com.example.demo.responseDto.LoginResponseDto;
 import com.example.demo.responseDto.TokenRequestDto;
 import com.example.demo.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,10 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(
+            summary = "구글 로그인",
+            description = "Google ID 토큰을 받아 사용자를 로그인 처리하고 JWT를 반환한다."
+    )
     @PostMapping("/google")
     public ResponseEntity<LoginResponseDto> googleLogin(@RequestBody TokenRequestDto tokenRequest) {
         String token = authService.loginWithGoogle(tokenRequest.getIdToken());

--- a/demo/src/main/java/com/example/demo/controller/BookmarkController.java
+++ b/demo/src/main/java/com/example/demo/controller/BookmarkController.java
@@ -5,6 +5,7 @@ import com.example.demo.responseDto.BookmarkResponseDto;
 import com.example.demo.responseDto.StampBoardDto;
 import com.example.demo.service.BookmarkService;
 import com.example.demo.domain.Bookmark;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +24,7 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
     private final BookmarkRepository bookmarkRepository;
 
+    @Operation(summary = "사용자의 북마크 전체 또는 방문 여부 필터링 조회")
     @GetMapping("/{userId}/bookmarks") // 아이디 보고 북마크 가져오기
     public List<BookmarkResponseDto> getBookmarksByUser(
             @PathVariable Long userId,
@@ -37,6 +39,7 @@ public class BookmarkController {
 
 
     // 게시글로 북마크 추가
+    @Operation(summary = "게시글 ID로 북마크 추가")
     @PostMapping("/{postId}")
     public ResponseEntity<?> bookmark(@PathVariable Long postId, @RequestParam Long userId) {
         bookmarkService.addBookmark(userId, postId);
@@ -44,12 +47,14 @@ public class BookmarkController {
     }
 
     // 북마크 취소
+    @Operation(summary = "게시글 ID로 북마크 취소")
     @DeleteMapping("/{postId}")
     public ResponseEntity<?> unbookmark(@PathVariable Long postId, @RequestParam Long userId) {
         bookmarkService.removeBookmark(userId, postId);
         return ResponseEntity.ok("북마크 취소됨");
     }
 
+    @Operation(summary = "장소 정보로 북마크 추가 (검색 기반)")
     @PostMapping("/search") // 검색으로 북마크 추가
     public ResponseEntity<String> addBookmarkBySearch(
             @RequestParam Long userId,
@@ -63,6 +68,7 @@ public class BookmarkController {
     }
 
     // 이 북마크가 어디 스탬프판에 속하는지 불러옴
+    @Operation(summary = "특정 북마크가 속한 스탬프판 리스트 조회")
     @GetMapping("/{bookmarkId}/stampboards")
     public ResponseEntity<List<StampBoardDto>> getBoardsForBookmark(@PathVariable Long bookmarkId) {
         Bookmark bookmark = bookmarkRepository.findById(bookmarkId)

--- a/demo/src/main/java/com/example/demo/controller/PostController.java
+++ b/demo/src/main/java/com/example/demo/controller/PostController.java
@@ -4,6 +4,7 @@ import com.example.demo.responseDto.PostRequestDto;
 import com.example.demo.responseDto.PostResponseDto;
 import com.example.demo.service.PostService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,11 +20,13 @@ public class PostController {
 
     private final PostService postService;
 
+    @Operation(summary = "전체 게시글 목록 조회")
     @GetMapping("/allPosts") // 게시판에 올라온 모든 게시글 조회
     public List<PostResponseDto> getAllPosts() {
         return postService.getAllPosts();
     }
 
+    @Operation(summary = "키워드로 게시글 검색")
     @GetMapping("/search") // 검색 기능
     public List<PostResponseDto> searchPosts(@RequestParam("keyword") String keyword) {
         return postService.searchPosts(keyword).stream()
@@ -31,26 +34,24 @@ public class PostController {
                 .toList();
     }
 
+    @Operation(summary = "게시글 등록")
     @PostMapping("/")
     public ResponseEntity<?> createPost(@RequestBody PostRequestDto dto) {
         postService.createPost(dto);
         return ResponseEntity.ok("게시글 작성 완료");
     }
 
+    @Operation(summary = "게시글 수정")
     @PutMapping("/{postId}")
     public ResponseEntity<?> updatePost(@PathVariable Long postId, @RequestBody PostRequestDto dto) {
         postService.updatePost(postId, dto);
         return ResponseEntity.ok("게시글 수정 완료");
     }
 
+    @Operation(summary = "게시글 삭제")
     @DeleteMapping("/{postId}")
     public ResponseEntity<?> deletePost(@PathVariable Long postId) {
         postService.deletePost(postId);
         return ResponseEntity.ok("게시글 삭제 완료");
     }
-
 }
-
-
-
-

--- a/demo/src/main/java/com/example/demo/controller/ShareLinkController.java
+++ b/demo/src/main/java/com/example/demo/controller/ShareLinkController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import com.example.demo.service.ShareLinkService;
 import com.example.demo.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +18,14 @@ public class ShareLinkController {
 
     private final ShareLinkService shareLinkService;
 
+    @Operation(summary = "스탬프판 공유 링크 생성")
     @PostMapping("/{stampBoardId}")
     public ResponseEntity<String> createShareLink(@PathVariable Long stampBoardId) {
         String url = shareLinkService.createShareLink(stampBoardId);
         return ResponseEntity.ok(url);
     }
 
+    @Operation(summary = "공유 링크로 스탬프판 복사")
     @GetMapping("/{uuid}")
     public ResponseEntity<String> importSharedBoard(@PathVariable String uuid,
                                                     @AuthenticationPrincipal User user) {

--- a/demo/src/main/java/com/example/demo/controller/StampBoardController.java
+++ b/demo/src/main/java/com/example/demo/controller/StampBoardController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import com.example.demo.service.StampBoardService;
 import com.example.demo.domain.StampBoard;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ public class StampBoardController {
     private final StampBoardService stampBoardService;
 
     // 보드 생성
+    @Operation(summary = "스탬프보드 생성")
     @PostMapping
     public ResponseEntity<StampBoard> createBoard(@RequestParam Long userId,
                                                   @RequestParam String title, @RequestParam String color) {
@@ -27,6 +29,7 @@ public class StampBoardController {
     }
 
     // 보드 이름 수정
+    @Operation(summary = "스탬프보드 제목 수정")
     @PatchMapping("/{boardId}/title")
     public ResponseEntity<?> updateBoardTitle(@PathVariable Long boardId, @RequestParam String title) {
         stampBoardService.updateBoardTitle(boardId, title);
@@ -34,6 +37,7 @@ public class StampBoardController {
     }
 
     // 보드 컬러 수정
+    @Operation(summary = "스탬프보드 컬러 수정")
     @PatchMapping("/{boardId}/color")
     public ResponseEntity<?> updateBoardColor(@PathVariable Long boardId, @RequestParam String color) {
         stampBoardService.updateBoardColor(boardId, color);
@@ -41,18 +45,21 @@ public class StampBoardController {
     }
 
     // 유저의 보드 목록 조회
+    @Operation(summary = "사용자의 스탬프보드 목록 조회")
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<StampBoard>> getBoardsByUser(@PathVariable Long userId) {
         return ResponseEntity.ok(stampBoardService.getStampBoardsByUser(userId));
     }
 
     // 특정 보드 상세 조회
+    @Operation(summary = "스탬프보드 상세 조회")
     @GetMapping("/{id}")
     public ResponseEntity<StampBoard> getBoard(@PathVariable Long id) {
         return ResponseEntity.ok(stampBoardService.getStampBoard(id));
     }
 
     // 보드 삭제
+    @Operation(summary = "스탬프보드 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteBoard(@PathVariable Long id) {
         stampBoardService.deleteStampBoard(id);
@@ -60,6 +67,7 @@ public class StampBoardController {
     }
 
     // 스탬프보드에 북마크 추가
+    @Operation(summary = "스탬프보드에 북마크 추가")
     @PostMapping("/{boardId}/bookmark")
     public ResponseEntity<?> addBookmark(@PathVariable Long boardId,
                                          @RequestBody Long bookmarkId) {
@@ -74,6 +82,7 @@ public class StampBoardController {
     }
 
     // 스탬프보드에서 북마크 삭제
+    @Operation(summary = "스탬프보드에서 북마크 삭제")
     @DeleteMapping("/{boardId}/bookmark")
     public ResponseEntity<?> removeBookmark(@PathVariable Long boardId,
                                             @RequestBody Long bookmarkId) {
@@ -83,10 +92,6 @@ public class StampBoardController {
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
-
-
     }
-
-
 }
 

--- a/demo/src/main/java/com/example/demo/controller/TestController.java
+++ b/demo/src/main/java/com/example/demo/controller/TestController.java
@@ -1,13 +1,17 @@
 package com.example.demo.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "JWT 인증 테스트 API", description = "JWT 인증이 필요한 보호된 API 테스트용")
 @RestController
 @RequestMapping("/api/secure")
 public class TestController {
 
+    @Operation(summary = "JWT 인증 테스트용 API")
     @GetMapping("/test")
     public String secureEndpoint() {
         return "✅ JWT 인증 완료! 보호된 API 접근 성공";

--- a/demo/src/main/resources/application.properties
+++ b/demo/src/main/resources/application.properties
@@ -9,4 +9,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
+springdoc.swagger-ui.path=/docs
+springdoc.api-docs.path=/openapi
+
 


### PR DESCRIPTION
### 주요 변경사항
1. Google OAuth2 로그인 기능 구현 (`/api/auth/google`)
2. JWT 기반 보안 설정 적용 및 `/docs` 경로로 Swagger UI 접근 가능하게 설정
3. Swagger 문서 커스터마이징:
   - 각 API 그룹별 설명(`@Tag`) 추가
   - Swagger UI 기본 경로를 `/docs`로 변경 
     원래 주소: http://localhost:8080/swagger-ui/index.html
     바뀐 주소: http://localhost:8080/docs
    
     로컬이 아닌 프론트 같은 외부에서 접속 시 ngrok을 이용할 것
4. Security 설정에서 Swagger 관련 endpoint 예외 처리

### 확인 방법
- 로컬에서 `localhost:8080/docs` 접속 시 API 문서 확인 가능
- 테스트용 보호된 API: `/api/secure/test` (JWT 인증 필요)

