### PR TITLE
feat: 유저 API 구현 및 Swagger UI  설정 추가

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -25,38 +25,44 @@ repositories {
 }
 
 dependencies {
+	// ✅ Spring Boot Starters
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// ✅ Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// ✅ DB
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// ✅ 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-// ✅ OAuth 관련
+	// ✅ OAuth (Google)
 	implementation 'com.google.oauth-client:google-oauth-client:1.34.1'
 	implementation 'com.google.api-client:google-api-client:2.2.0'
 	implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
 
-// ✅ JWT
+	// ✅ JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-// ✅ Swagger
+	// ✅ Swagger (SpringDoc OpenAPI)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
-
-// ✅ Jackson (Swagger와 호환 맞추기)
-	implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.2'
-
+}
+dependencyManagement {
+	imports {
+		// ✅ 정확한 jackson 버전 고정 (Swagger가 호환되는 안정 버전)
+		mavenBom "com.fasterxml.jackson:jackson-bom:2.15.2"
+	}
 }
 
 
+// ✅ 테스트 설정
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",                 // Swagger UI
                                 "/swagger-ui.html",               // Swagger HTML 진입점
                                 "/openapi/**",              // 우리가 설정한 API docs 커스텀 경로
+                                "/openapi.json",            // Swagger가 이거 요청하는 경우 있음
+                                "/openapi.yaml",
                                 "/docs/**",                 // 우리가 커스터마이징한 Swagger UI 경로
                                 "/swagger-resources/**",          // Swagger 리소스
                                 "/webjars/**"                     // Swagger 스타일/스크립트

--- a/demo/src/main/java/com/example/demo/controller/UserController.java
+++ b/demo/src/main/java/com/example/demo/controller/UserController.java
@@ -1,0 +1,69 @@
+package com.example.demo.controller;
+
+import com.example.demo.requestDto.UpdateNicknameRequestDto;
+import com.example.demo.responseDto.UserInfoResponseDto;
+import com.example.demo.repository.UserRepository;
+import com.example.demo.domain.User;
+import com.example.demo.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User", description = "유저 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserRepository userRepository;
+
+    @Operation(summary = "내 정보 조회", description = "JWT로 인증된 내 유저 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponseDto> getMyInfo() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = (String) authentication.getPrincipal();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        return ResponseEntity.ok(new UserInfoResponseDto(user));
+    }
+
+    private final UserService userService;
+
+    //사용자 정보 조회
+    @Operation(summary = "유저 단일 조회", description = "ID로 유저 정보를 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUser(@PathVariable Long id) {
+        User user = userService.getUserById(id);
+        return ResponseEntity.ok(user);
+    }
+
+    //사용자 탈퇴
+    @Operation(summary = "유저 탈퇴", description = "ID로 유저를 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.ok("사용자가 성공적으로 삭제되었습니다.");
+    }
+
+    //닉네임 변경
+    @Operation(summary = "닉네임 변경", description = "JWT로 인증된 유저의 닉네임을 수정합니다.")
+    @PatchMapping("/me")
+    public ResponseEntity<String> updateNickname(@RequestBody UpdateNicknameRequestDto request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = (String) authentication.getPrincipal();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        userService.updateNickname(user.getId(), request.getNickname());
+
+        return ResponseEntity.ok("닉네임이 성공적으로 변경되었습니다.");
+    }
+}

--- a/demo/src/main/java/com/example/demo/domain/User.java
+++ b/demo/src/main/java/com/example/demo/domain/User.java
@@ -13,12 +13,19 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long id; //DB에서 자동 증가하는 기본키 (PK)
 
     @Column(nullable = false)
-    private String oauthId; // ✅ 카멜케이스 추천
+    private String oauthId; // 구글에서 내려준 유저 식별자 (변경 불가)
 
     @Column(nullable = false)
     private String email;
+
+    @Column(nullable = true)
+    private String nickname;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 
 }

--- a/demo/src/main/java/com/example/demo/repository/UserRepository.java
+++ b/demo/src/main/java/com/example/demo/repository/UserRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauthId(String sub);
 
+    // 이메일로 사용자 찾기
     Optional<User> findByEmail(String email);
 }

--- a/demo/src/main/java/com/example/demo/requestDto/UpdateNicknameRequestDto.java
+++ b/demo/src/main/java/com/example/demo/requestDto/UpdateNicknameRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.demo.requestDto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameRequestDto {
+    private String nickname;
+}

--- a/demo/src/main/java/com/example/demo/responseDto/UserInfoResponseDto.java
+++ b/demo/src/main/java/com/example/demo/responseDto/UserInfoResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.demo.responseDto;
+
+import com.example.demo.domain.User;
+import lombok.Getter;
+
+@Getter
+public class UserInfoResponseDto {
+    private Long id;
+    private String email;
+    private String nickname; // ✅ 닉네임 추가
+
+    public UserInfoResponseDto(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.nickname = user.getNickname(); // ✅ 매핑
+    }
+}

--- a/demo/src/main/java/com/example/demo/service/UserService.java
+++ b/demo/src/main/java/com/example/demo/service/UserService.java
@@ -1,0 +1,41 @@
+package com.example.demo.service;
+
+import com.example.demo.domain.User;
+import com.example.demo.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 ID로 사용자 정보 조회
+     */
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
+    }
+
+    /**
+     * 사용자 삭제 (탈퇴)
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("해당 사용자가 존재하지 않습니다.");
+        }
+        userRepository.deleteById(userId);
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, String newNickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.updateNickname(newNickname); // 엔티티에 setter 메서드 추가 필요
+    }
+
+}


### PR DESCRIPTION
유저 엔티티에 닉네임 필드를 추가했고,
유저 API를 추가했습니다.
유저가 닉네임 변경 및 탈퇴할 수 있도록 했습니다.
swagger에도 반영 완료했습니다.
관련 기능은 /api/user/** 경로에 위치합니다.