### PR TITLE
bapmark.jar 수정 , db 를 RDS로 연결하는 prod.properties 추가

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -9,6 +9,7 @@ bootJar {
 	archiveFileName = 'bapmark.jar' // 원하는 실행파일 이름
 }
 
+
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 

--- a/demo/src/main/resources/application-prod.properties
+++ b/demo/src/main/resources/application-prod.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:mysql://bapmarkdb.cxagic8i076b.ap-northeast-2.rds.amazonaws.com:3306/mapdb?sslMode=REQUIRED&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=HICC3
+spring.datasource.password=cscs1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
- 로컬 db랑 연결하는 application.properties는 만일을 대비해 그대로 놔두고 application-prod.properties를 추가했습니다. prod.properties는 RDS와 연결되도록 합니다.

-bapmark.jar 를 첨부했습니다 (용량 커서 main에 계속 놔둬도 좋을지 모르겠음)

앱 실행하려면 ec2 에 접속해서  bapmark.jar 올리고  java -jar -Dspring.profiles.active=prod bapmark.jar --server.address=0.0.0.0
이런 류의 명령어를 해야 합니다. (application.properties가 아니라 application-prod.properties 를 실행하도록 해야 함)


